### PR TITLE
fix typo in variable name

### DIFF
--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -89,7 +89,8 @@ CACHE - cache file for wakatime api."
         (wakatime-ui--update-time (concat
                                    (replace-regexp-in-string "\n\\'" "" output)
                                    " "))))
-    (shell-command-sentinel process signal)
+    (cl-letf (((symbol-function #'message) (symbol-function #'ignore)))
+      (shell-command-sentinel process signal))
     (setq wakatime-ui--busy nil)))
 
 (defun wakatime-ui--get-changes ()

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -33,8 +33,10 @@
   :group 'wakatime-ui
   :type 'int)
 
-(defcustom wakatim-ui-schedule-url nil
-  "Url of chart.")
+(defcustom wakatime-ui-schedule-url nil
+  "Url of chart."
+  :group 'wakatime-ui
+  :type 'string)
 
 (defface wakatime-ui--modeline-face
   '((t :foreground "#f65866"

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -125,7 +125,7 @@ CACHE - cache file for wakatime api."
   (add-to-list 'mode-line-format
                '(:eval
                  (when wakatime-ui-mode
-                   (propertize wakatime-ui-current-session-text 'face '(:foreground "#f65866")))) t))
+                   (propertize wakatime-ui-current-session-text 'face 'wakatime-ui--modeline-face))) t))
 
 ;;;###autoload
 (define-minor-mode wakatime-ui-mode

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -117,16 +117,8 @@ CACHE - cache file for wakatime api."
     (setq wakatime-ui--check-timer
           (run-with-timer 20 wakatime-ui--update-timeout 'wakatime-ui--get-changes))))
 
-(defun wakatime-ui--watch-time ()
-  "Subscribe to time activity.
-Could be stopped by `wakatime-ui--stop-watch-time'"
-  (if (bound-and-true-p doom-first-file-hook)
-      (add-hook 'doom-first-file-hook 'wakatime-ui--start-watch-time)
-    (wakatime-ui--start-watch-time)))
-
 (defun wakatime-ui--stop-watch-time ()
   "Stop to subscribe time activity."
-  (remove-hook 'doom-first-file-hook 'wakatime-ui--start-watch-time)
   (when wakatime-ui--check-timer
     (cancel-timer wakatime-ui--check-timer)
     (setq wakatime-ui--check-timer nil)))
@@ -148,7 +140,7 @@ Could be stopped by `wakatime-ui--stop-watch-time'"
   (if wakatime-ui-mode
       (progn
         (wakatime-ui--get-changes)
-        (wakatime-ui--watch-time))
+        (wakatime-ui--start-watch-time))
     (wakatime-ui--stop-watch-time)))
 
 ;;;###autoload

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -63,7 +63,6 @@
 
 (defun wakatime-ui--update-time (text)
   "Update mode line information by TEXT."
-  (setq text (concat text " "))
   (let* ((already-in-modeline-p (assoc 'wakatime-ui-mode mode-line-misc-info))
          (content (propertize text 'face 'wakatime-ui--modeline-face)))
     (when already-in-modeline-p
@@ -86,9 +85,7 @@ CACHE - cache file for wakatime api."
       (switch-to-buffer-other-window buffer-name)
       (let* ((output (buffer-substring (point-min) (point-max))))
         (kill-matching-buffers buffer-name nil t)
-        (wakatime-ui--update-time (concat
-                                   (replace-regexp-in-string "\n\\'" "" output)
-                                   " "))))
+        (wakatime-ui--update-time (replace-regexp-in-string "\n\\'" "" output))))
     (cl-letf (((symbol-function #'message) (symbol-function #'ignore)))
       (shell-command-sentinel process signal))
     (setq wakatime-ui--busy nil)))

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -39,9 +39,7 @@
   :type 'string)
 
 (defface wakatime-ui--modeline-face
-  '((t :foreground "#f65866"
-       :background nil
-       :bold t))
+  '((t :inherit modeline))
   "Face for wakatime ui modeline info."
   :group 'wakatime-ui)
 

--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -64,13 +64,12 @@
 (defun wakatime-ui--update-time (text)
   "Update mode line information by TEXT."
   (setq text (concat text " "))
-  (when (boundp 'doom-modeline-mode)
-    (let* ((already-in-modeline-p (assoc 'wakatime-ui-mode mode-line-misc-info))
-           (content (propertize text 'face '(:foreground "#f65866"))))
-      (when already-in-modeline-p
-        (setf mode-line-misc-info (assoc-delete-all 'wakatime-ui-mode mode-line-misc-info)))
-      (add-to-list 'mode-line-misc-info `(wakatime-ui-mode ,content))
-      (setq wakatime-ui-current-session-text text))))
+  (let* ((already-in-modeline-p (assoc 'wakatime-ui-mode mode-line-misc-info))
+         (content (propertize text 'face 'wakatime-ui--modeline-face)))
+    (when already-in-modeline-p
+      (setf mode-line-misc-info (assoc-delete-all 'wakatime-ui-mode mode-line-misc-info)))
+    (add-to-list 'mode-line-misc-info `(wakatime-ui-mode ,content))
+    (setq wakatime-ui-current-session-text text)))
 
 (defun wakatime-ui--clear-modeline (&optional directory cache)
   "Clear modeline information.


### PR DESCRIPTION
Hi. I added these changes to your package for my personal usage. I think most of them are pretty important since they make the package usable on non-Doom Emacs, etc.