### PR TITLE
fix: ensure space after modeline segment

### DIFF
--- a/wakatime-ui.el
+++ b/wakatime-ui.el
@@ -85,7 +85,8 @@ CACHE - cache file for wakatime api."
       (switch-to-buffer-other-window buffer-name)
       (let* ((output (buffer-substring (point-min) (point-max))))
         (kill-matching-buffers buffer-name nil t)
-        (wakatime-ui--update-time (replace-regexp-in-string "\n\\'" "" output))))
+        (wakatime-ui--update-time
+         (concat (replace-regexp-in-string "\n\\'" "" output) " "))))
     (cl-letf (((symbol-function #'message) (symbol-function #'ignore)))
       (shell-command-sentinel process signal))
     (setq wakatime-ui--busy nil)))


### PR DESCRIPTION
For some reason LSP inserts its diagnostics afterward without padding with a space whereas Eglot does not. Weird.